### PR TITLE
Add .gitignore for TypeScript applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+
+# OS
+.DS_Store
+
+# Test coverage
+coverage/


### PR DESCRIPTION
## Summary
- add .gitignore tailored for Node/TypeScript projects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689252ada36c832f89fae9824c9acc25